### PR TITLE
fix(deps): bump axios to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@vueuse/core": "10.11.1",
 		"@wangeditor-next/editor": "5.6.56",
 		"@wangeditor-next/editor-for-vue": "5.1.14",
-		"axios": "1.15.2",
+		"axios": "1.16.0",
 		"codemirror": "5.65.21",
 		"crypto-js": "4.2.0",
 		"disable-devtool": "0.3.9",


### PR DESCRIPTION
## Summary

Bumps the direct `axios` dependency from `1.15.2` to `1.16.0`.

## Why

Dependabot alert 108 reports `GHSA-35jp-ww65-95wh` / `CVE-2026-44494`, where vulnerable axios versions are `>= 1.0.0, < 1.16.0`. `1.16.0` is the first patched version.

## Impact

This keeps the fix scoped to the affected runtime dependency. No lockfile was updated because this repository does not currently commit a `pnpm-lock.yaml`.

## Validation

- `npm view axios@1.16.0 version`
- `pnpm install --lockfile=false --ignore-scripts`
- `node -p "require('./node_modules/axios/package.json').version + ' / vite ' + require('./node_modules/vite/package.json').version"`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a third-party library to a newer version, which may include general stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->