### PR TITLE
fix(deps): bump vue-i18n to 9.14.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"vue": "3.5.35",
 		"vue-clipboard3": "2.0.0",
 		"vue-echarts": "7.0.3",
-		"vue-i18n": "9.2.2",
+		"vue-i18n": "9.14.3",
 		"vue-router": "4.6.4",
 		"vue3-tree-org": "4.2.2",
 		"vuedraggable": "4.1.0"


### PR DESCRIPTION
## Summary

Bumps the direct `vue-i18n` dependency from `9.2.2` to `9.14.3`.

## Why

Dependabot alert 36 reports `GHSA-p2ph-7g93-hw3m` / `CVE-2025-27597`, a prototype pollution issue in Vue I18n's flat JSON handling. The affected range for `vue-i18n` is `>= 9.1.0, < 9.14.3`, and `9.14.3` is the first patched version in the current major line.

## Impact

This keeps the fix scoped to the affected runtime dependency. `vue-i18n@9.14.3` resolves to `@intlify/core-base@9.14.3` in the installed dependency tree. No lockfile was updated because this repository does not currently commit a `pnpm-lock.yaml`.

## Validation

- `pnpm list vue-i18n @intlify/core-base --depth 1`
- `node -p "require('./node_modules/vue-i18n/package.json').version"`
- `git diff --check`
- `pnpm build`

`pnpm audit --prod --audit-level high` could not run because pnpm requires a lockfile and this repository has no `pnpm-lock.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s translation library to a newer version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->