### PR TITLE
refactor(widget): adjust default layout order

### DIFF
--- a/src/views/admin/system/role/widget.vue
+++ b/src/views/admin/system/role/widget.vue
@@ -111,8 +111,8 @@ const layoutOptions = [
 			spans: [8, 8, 8],
 			defaultComps: [
 				['current-user', 'favorite-menu', 'sys-log-line', 'session-uv-summary'],
-				['news', 'sys-log', 'device-distribution'],
-				['calendar', 'popular-pages', 'browser-distribution'],
+				['news', 'sys-log', 'popular-pages'],
+				['calendar', 'device-distribution', 'browser-distribution'],
 			],
 		},
 	{

--- a/src/views/home/widgets/index.vue
+++ b/src/views/home/widgets/index.vue
@@ -143,8 +143,8 @@ const { t } = useI18n();
 		layout: [7, 7, 10],
 		copmsList: [
 			['current-user', 'favorite-menu', 'sys-log-line', 'session-uv-summary'],
-			['news', 'sys-log', 'device-distribution'],
-			['calendar', 'popular-pages', 'browser-distribution'],
+			['news', 'sys-log', 'popular-pages'],
+			['calendar', 'device-distribution', 'browser-distribution'],
 		],
 	});
 


### PR DESCRIPTION
## Summary
- Adjust the default 7/7/10 widget layout so popular pages are grouped with news/system logs.
- Move device distribution into the right column while keeping open-source-only widgets in place.

## Validation
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the default dashboard layout so key widgets now appear in the intended sections.
  * Swapped the placement of the device distribution and popular pages widgets in the default grid and role-based layout, improving the initial page arrangement when no custom settings are saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->