### PR TITLE
feat(menu): copy icon names from form

### DIFF
--- a/src/views/admin/system/menu/form.vue
+++ b/src/views/admin/system/menu/form.vue
@@ -46,7 +46,10 @@
         <el-input-number v-model="state.ruleForm.sortOrder" :min="0" controls-position="right"/>
       </el-form-item>
       <el-form-item :label="$t('sysmenu.icon')" prop="icon" v-if="state.ruleForm.menuType === '0'">
-        <IconSelector :placeholder="$t('sysmenu.inputIconTip')" v-model="state.ruleForm.icon"/>
+        <div class="flex w-full items-center gap-2">
+          <IconSelector class="flex-1" :placeholder="$t('sysmenu.inputIconTip')" v-model="state.ruleForm.icon"/>
+          <el-button icon="document-copy" :title="$t('sysmenu.copyIcon')" :disabled="!state.ruleForm.icon" @click="copyText(state.ruleForm.icon)" />
+        </div>
       </el-form-item>
       <el-row>
         <el-col :span="12">
@@ -117,11 +120,13 @@ import {useI18n} from 'vue-i18n';
 import {getObj, pageList, putObj, addObj, validateExist} from '/@/api/admin/menu';
 import {useMessage} from '/@/hooks/message';
 import {rule, validateNull} from "/@/utils/validate";
+import commonFunction from '/@/utils/commonFunction';
 import Tip from "/@/components/Tip/index.vue";
 
 // 定义子组件向父组件传值/事件
 const emit = defineEmits(['refresh']);
 const {t} = useI18n();
+const {copyText} = commonFunction();
 // 引入组件
 const IconSelector = defineAsyncComponent(() => import('/@/components/IconSelector/index.vue'));
 

--- a/src/views/admin/system/menu/i18n/en.ts
+++ b/src/views/admin/system/menu/i18n/en.ts
@@ -15,6 +15,7 @@ export default {
         component: 'Component',
         visible: 'Visible',
         icon: 'Icon',
+        copyIcon: 'Copy Icon Name',
         inputMenuIdTip: 'Please enter menu ID',
         inputPermissionTip: 'Please enter permission',
         inputPathTip: 'Please enter path',

--- a/src/views/admin/system/menu/i18n/zh-cn.ts
+++ b/src/views/admin/system/menu/i18n/zh-cn.ts
@@ -15,6 +15,7 @@ export default {
         component: '组件',
         visible: '显示',
         icon: '图标',
+        copyIcon: '复制图标名称',
         inputMenuIdTip: '请输入菜单ID',
         inputCreateByTip: '请输入创建人',
         inputCreateTimeTip: '请输入创建时间',


### PR DESCRIPTION
## Summary
- Add a copy button next to the menu icon selector.
- Disable the button when no icon is selected.
- Add English and Chinese menu i18n labels for the copy action.

## Validation
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copy button next to the menu icon field so icon names can be copied more easily.
  * Added supporting text in English and Chinese for the new copy action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->