### PR TITLE
fix(router): skip empty routes and log login errors

### DIFF
--- a/src/router/backEnd.ts
+++ b/src/router/backEnd.ts
@@ -88,13 +88,33 @@ export function setFilterRouteEnd() {
 }
 
 /**
+ * 递归过滤 path 为空的路由（含嵌套 children），避免 addRoute 报错
+ * @param routes 待过滤的路由数组
+ * @returns 过滤后的路由数组
+ */
+function filterEmptyPathRoutes(routes: RouteRecordRaw[]): RouteRecordRaw[] {
+	return routes
+		.filter((route) => {
+			if (!route.path) {
+				console.error('[router] 跳过 path 为空的路由，请检查后端菜单配置:', route); // eslint-disable-line no-console
+				return false;
+			}
+			return true;
+		})
+		.map((route) => {
+			if (route.children?.length) route.children = filterEmptyPathRoutes(route.children);
+			return route;
+		});
+}
+
+/**
  * 添加动态路由
  * @method router.addRoute
  * @description 此处循环为 baseRoutes（/@/router/route）第一个顶级 children 的路由一维数组，非多级嵌套
  * @link 参考：https://next.router.vuejs.org/zh/api/#addroute
  */
 export async function setAddRoute() {
-	await setFilterRouteEnd().forEach((route: RouteRecordRaw) => {
+	await filterEmptyPathRoutes(setFilterRouteEnd()).forEach((route: RouteRecordRaw) => {
 		router.addRoute(route);
 	});
 }

--- a/src/stores/userInfo.ts
+++ b/src/stores/userInfo.ts
@@ -41,6 +41,7 @@ export const useUserInfo = defineStore('userInfo', {
 						resolve(res);
 					})
 					.catch((err) => {
+						console.error('[login] 登录失败:', err); // eslint-disable-line no-console
 						useMessage().error(err?.msg || '系统异常请联系管理员');
 						reject(err);
 					});
@@ -64,6 +65,7 @@ export const useUserInfo = defineStore('userInfo', {
 						resolve(res);
 					})
 					.catch((err) => {
+						console.error('[login] 登录失败:', err); // eslint-disable-line no-console
 						useMessage().error(err?.msg || '系统异常请联系管理员');
 						reject(err);
 					});
@@ -88,6 +90,7 @@ export const useUserInfo = defineStore('userInfo', {
 						resolve(res);
 					})
 					.catch((err) => {
+						console.error('[login] 登录失败:', err); // eslint-disable-line no-console
 						useMessage().error(err?.msg || '系统异常请联系管理员');
 						reject(err);
 					});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -78,7 +78,8 @@ const viteConfig = defineConfig((mode: ConfigEnv) => {
 			minify: isDev ? ('esbuild' as const) : ('terser' as const),
 			terserOptions: {
 				compress: {
-					drop_console: true, // 删除 console
+					// 只删除 log/info/debug，保留 console.error / console.warn 便于生产排查
+					pure_funcs: ['console.log', 'console.info', 'console.debug'],
 					drop_debugger: true, // 删除 debugger
 				},
 				format: {


### PR DESCRIPTION
## Summary
- skip backend routes with empty path before calling router.addRoute
- log login failure details for password, mobile, and social login flows
- keep console.error and console.warn in production builds while dropping low-value console calls

## Validation
- pnpm build
- git diff --check