### PR TITLE
ci: use Node 20.19.0 for Vite builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18', '24']
+        node-version: ['20.19.0']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What changed

- Updated the GitHub Actions CI Node matrix from `18` / `24` to `20.19.0`.

## Why

The project is on Vite `8.1.0`, and both `package.json` and the lockfile require Node `>=20.19.0` / `^20.19.0 || >=22.12.0`. Running CI on Node 18 no longer matches the supported runtime.

## Impact

CI now builds with the minimum supported Node 20 runtime expected by the current Vite toolchain.

## Validation

- `npm install`
- `git diff --check`
- `npm run build`