### PR TITLE
chore: bump version to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img src="https://img.shields.io/badge/Pig-4.0-success.svg" alt="Build Status">
+ <img src="https://img.shields.io/badge/Pig-4.1-success.svg" alt="Build Status">
  <img src="https://img.shields.io/badge/Spring%20Cloud-2025.1-blue.svg" alt="Coverage Status">
  <img src="https://img.shields.io/badge/Spring%20Boot-4.0-blue.svg" alt="Downloads">
  <img src="https://img.shields.io/badge/Vue-3.5-blue.svg" alt="Downloads">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pig-ui",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"description": "Pig 开源权限管理与微服务脚手架",
 	"author": "pig4cloud",
 	"license": "Apache-2.0",

--- a/src/components/Verifition/README.md
+++ b/src/components/Verifition/README.md
@@ -1,7 +1,7 @@
 # 验证码组件
 
 <p align="center">
- <img src="https://img.shields.io/badge/Pig%20UI-4.0-success.svg" alt="Pig UI">
+ <img src="https://img.shields.io/badge/Pig%20UI-4.1-success.svg" alt="Pig UI">
  <img src="https://img.shields.io/badge/Vue-3.5-blue.svg" alt="Vue">
  <img src="https://img.shields.io/badge/Element%20Plus-2.13-blue.svg" alt="Element Plus">
  <img src="https://img.shields.io/badge/Vite-5.4-blue.svg" alt="Vite">
@@ -24,7 +24,7 @@
 
 | 依赖 | 版本 | 用途 |
 | --- | --- | --- |
-| Pig UI | 4.0.0 | 当前前端工程版本 |
+| Pig UI | 4.1.0 | 当前前端工程版本 |
 | Vue | 3.5.34 | 组件运行框架 |
 | Element Plus | 2.13.7 | 弹窗、按钮、输入框等基础组件 |
 | Vite | 5.4.21 | 本地开发与构建 |


### PR DESCRIPTION
## Summary

- Bump `pig-ui` package metadata to `4.1.0`.
- Refresh README version badges and component documentation version display.

## Impact

This keeps the frontend package and documentation metadata aligned for the `4.1.0` release line.

## Validation

- `npm pkg get version`
- `git diff --cached --check`