### PR TITLE
refactor(clarity): 重构网站分析看板

### DIFF
--- a/src/views/tools/data/clarity.vue
+++ b/src/views/tools/data/clarity.vue
@@ -1,280 +1,67 @@
-<template>
-	<div class="min-h-full bg-slate-100 p-6 dark:bg-slate-900">
-
-		<!-- ── 骨架屏 ── -->
-		<div v-if="pageLoading" class="animate-pulse">
-			<div class="mb-6 flex flex-wrap items-center gap-2">
-				<div v-for="i in 3" :key="i" class="h-9 w-28 rounded-full bg-slate-200 dark:bg-slate-700" />
-				<div class="ml-auto h-9 w-48 rounded-xl bg-slate-200 dark:bg-slate-700" />
-			</div>
-			<div class="mb-5 grid grid-cols-2 gap-3.5 md:grid-cols-3 xl:grid-cols-6">
-				<div v-for="i in 6" :key="i" class="rounded-2xl bg-white p-[18px] dark:bg-slate-800">
-					<div class="mb-2 h-3 w-3/5 rounded bg-slate-200 dark:bg-slate-700" />
-					<div class="mb-3 h-7 w-4/5 rounded bg-slate-200 dark:bg-slate-700" />
-					<div class="flex h-8 items-end gap-1">
-						<div v-for="(h, j) in [40,60,45,70,55,85]" :key="j"
-							class="flex-1 rounded-t bg-slate-200 dark:bg-slate-700"
-							:style="{ height: h + '%' }" />
-					</div>
-				</div>
-			</div>
-			<div class="grid gap-4" style="grid-template-columns: 340px 1fr">
-				<div class="h-[340px] rounded-2xl bg-white dark:bg-slate-800" />
-				<div class="h-[340px] rounded-2xl bg-white dark:bg-slate-800" />
-			</div>
-		</div>
-
-		<!-- ── 数据拉取中 ── -->
-		<div v-else-if="clarityLoading"
-			class="flex min-h-[360px] flex-col items-center justify-center gap-3">
-			<svg class="h-10 w-10 animate-spin text-primary"
-				viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-				<path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"
-					stroke-linecap="round" />
-			</svg>
-			<p class="m-0 text-lg font-semibold text-slate-900 dark:text-slate-100">正在从 Clarity 拉取数据</p>
-			<p class="m-0 text-sm text-slate-400">{{ loadingMessage }}</p>
-			<button
-				class="inline-flex cursor-pointer items-center gap-1.5 rounded-lg border-0 bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-dark-2"
-				@click="loadData">
-				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
-					<path d="M1 4v6h6M23 20v-6h-6" stroke-linecap="round" stroke-linejoin="round" />
-					<path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4-4.64 4.36A9 9 0 0 1 3.51 15"
-						stroke-linecap="round" stroke-linejoin="round" />
-				</svg>
-				手动刷新
-			</button>
-		</div>
-
-		<!-- ── 主内容 ── -->
-		<template v-else>
-
-			<!-- 顶部筛选栏 -->
-			<div class="mb-5 flex flex-wrap items-center justify-between gap-3">
-				<div class="inline-flex gap-0.5 rounded-full border border-slate-200 bg-white p-1 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-					<button
-						v-for="opt in dayOptions"
-						:key="opt.value"
-						class="cursor-pointer whitespace-nowrap rounded-full border-0 px-4 py-1.5 text-[13px] font-medium transition-all"
-						:class="numOfDays === opt.value
-							? 'bg-primary text-white'
-							: 'bg-transparent text-slate-500 hover:bg-primary-light-9 hover:text-primary dark:text-slate-400 dark:hover:bg-primary-light-9 dark:hover:text-primary'"
-						@click="selectDays(opt.value)"
-					>{{ opt.label }}</button>
-				</div>
-
-				<div class="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-[13px] font-medium text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
-					<svg class="shrink-0 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-						stroke-width="2" width="13" height="13">
-						<rect x="3" y="4" width="18" height="18" rx="2" />
-						<path d="M16 2v4M8 2v4M3 10h18" stroke-linecap="round" stroke-linejoin="round" />
-					</svg>
-					{{ dateRangeLabel }}
-				</div>
-			</div>
-
-			<!-- 统计卡片 -->
-			<div class="mb-5 grid grid-cols-2 gap-3.5 md:grid-cols-3 xl:grid-cols-6">
-				<div
-					v-for="(card, i) in statisticsCards"
-					:key="i"
-					class="flex flex-col rounded-2xl border border-slate-100 bg-white p-[18px] shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700 dark:bg-slate-800"
-				>
-					<span class="mb-2 text-xs font-medium leading-tight text-slate-500 dark:text-slate-400">
-						{{ card.label }}
-					</span>
-					<div class="mb-4 text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
-						{{ card.value }}
-					</div>
-					<div class="sparkline">
-						<div
-							v-for="(h, j) in card.bars"
-							:key="j"
-							class="spark-bar"
-							:class="{ 'is-active': j === card.bars.length - 1 }"
-							:style="{ height: h + '%' }"
-						/>
-					</div>
-				</div>
-			</div>
-
-			<!-- 图表区域 -->
-			<div class="grid items-stretch gap-4 charts-grid">
-
-				<!-- 设备分布 -->
-				<div class="flex flex-col overflow-hidden rounded-2xl border border-slate-100 bg-white pb-2 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-					<div class="flex items-center border-b border-slate-100 px-5 py-[18px] dark:border-slate-700">
-						<span class="border-l-[3px] border-primary pl-2.5 text-[15px] font-semibold text-slate-900 dark:text-slate-100">
-							{{ $t('clarity.deviceDistribution', '设备分布') }}
-						</span>
-					</div>
-					<div class="flex-1 px-5 pt-2">
-						<v-chart class="h-[200px] w-full" :option="deviceChartOption" autoresize />
-					</div>
-					<div class="flex flex-col gap-2.5 px-5 pb-4 pt-3">
-						<div v-for="(item, i) in deviceList.slice(0, 3)" :key="i" class="flex items-center gap-2.5 text-[13px]">
-							<span class="h-2.5 w-2.5 shrink-0 rounded-full"
-								:style="{ background: deviceColors[i % deviceColors.length] }" />
-							<span class="flex-1 text-slate-500 dark:text-slate-400">{{ item.name }}</span>
-							<span class="text-sm font-semibold text-slate-900 dark:text-slate-100">
-								{{ getDevicePct(item.value) }}%
-							</span>
-						</div>
-					</div>
-				</div>
-
-				<!-- 浏览器分布 -->
-				<div class="flex flex-col overflow-hidden rounded-2xl border border-slate-100 bg-white pb-2 shadow-sm dark:border-slate-700 dark:bg-slate-800">
-					<div class="flex items-center border-b border-slate-100 px-5 py-[18px] dark:border-slate-700">
-						<span class="border-l-[3px] border-primary-light-3 pl-2.5 text-[15px] font-semibold text-slate-900 dark:text-slate-100">
-							{{ $t('clarity.browserDistribution', '浏览器分布') }}
-						</span>
-					</div>
-					<div class="flex-1 px-5 pt-2">
-						<v-chart class="h-[200px] w-full" :option="browserChartOption" autoresize />
-					</div>
-					<div class="flex flex-col gap-2.5 px-5 pb-4 pt-3">
-						<div v-for="(item, i) in browserList.slice(0, 3)" :key="i" class="flex items-center gap-2.5 text-[13px]">
-							<span class="h-2.5 w-2.5 shrink-0 rounded-full"
-								:style="{ background: browserColors[i % browserColors.length] }" />
-							<span class="flex-1 text-slate-500 dark:text-slate-400">{{ item.name }}</span>
-							<span class="text-sm font-semibold text-slate-900 dark:text-slate-100">
-								{{ getBrowserPct(item.value) }}%
-							</span>
-						</div>
-					</div>
-				</div>
-
-				<!-- 来源页面 Top5 -->
-				<div class="overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800">
-					<div class="flex items-center border-b border-slate-100 px-5 py-[18px] dark:border-slate-700">
-						<span class="border-l-[3px] border-primary pl-2.5 text-[15px] font-semibold text-slate-900 dark:text-slate-100">
-							{{ $t('clarity.referrerUrl', '来源页面 Top5') }}
-						</span>
-					</div>
-					<div class="py-2">
-						<div
-							v-for="(item, i) in referrerList"
-							:key="i"
-							class="px-5 py-2.5 transition-colors hover:bg-slate-50 dark:hover:bg-slate-700/50"
-						>
-							<div class="mb-1.5 flex items-baseline justify-between gap-2">
-								<span class="max-w-[65%] truncate text-[13px] font-medium text-slate-900 dark:text-slate-100"
-									:title="item.name">
-									{{ shortenUrl(item.name) }}
-								</span>
-								<span class="shrink-0 text-xs text-slate-500 dark:text-slate-400">
-									{{ item.value.toLocaleString() }} 次会话
-								</span>
-							</div>
-							<div class="h-1.5 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
-								<div class="progress-fill"
-									:style="{ width: getReferrerPct(item.value) + '%', transitionDelay: i * 0.04 + 's' }" />
-							</div>
-						</div>
-					</div>
-				</div>
-
-				<!-- 页面标题 Top5 -->
-				<div class="overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800">
-					<div class="flex items-center border-b border-slate-100 px-5 py-[18px] dark:border-slate-700">
-						<span class="border-l-[3px] border-primary-light-3 pl-2.5 text-[15px] font-semibold text-slate-900 dark:text-slate-100">
-							{{ $t('clarity.pageTitle', '页面标题 Top5') }}
-						</span>
-					</div>
-					<div class="py-2">
-						<div
-							v-for="(item, i) in pageTitleList"
-							:key="i"
-							class="px-5 py-2.5 transition-colors hover:bg-slate-50 dark:hover:bg-slate-700/50"
-						>
-							<div class="mb-1.5 flex items-baseline justify-between gap-2">
-								<span class="max-w-[65%] truncate text-[13px] font-medium text-slate-900 dark:text-slate-100"
-									:title="item.name">
-									{{ item.name }}
-								</span>
-								<span class="shrink-0 text-xs text-slate-500 dark:text-slate-400">
-									{{ item.value.toLocaleString() }} 次会话
-								</span>
-							</div>
-							<div class="h-1.5 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
-								<div class="progress-fill progress-fill-sky"
-									:style="{ width: getPageTitlePct(item.value) + '%', transitionDelay: i * 0.04 + 's' }" />
-							</div>
-						</div>
-					</div>
-				</div>
-
-				<!-- 热门页面 Top5 -->
-				<div class="overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800 charts-grid-full">
-					<div class="flex items-center justify-between border-b border-slate-100 px-5 py-[18px] dark:border-slate-700">
-						<span class="border-l-[3px] border-primary pl-2.5 text-[15px] font-semibold text-slate-900 dark:text-slate-100">
-							{{ $t('clarity.popularPages', '热门页面 Top5') }}
-						</span>
-						<button
-							class="inline-flex cursor-pointer items-center gap-1 rounded-lg border border-primary-light-8 bg-primary-light-9 px-3 py-1.5 text-xs font-medium text-primary transition-all hover:border-primary hover:bg-primary hover:text-white dark:border-primary-light-5 dark:bg-primary-light-9 dark:text-primary dark:hover:bg-primary dark:hover:text-white"
-							@click="exportCsv"
-						>
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12">
-								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"
-									stroke-linecap="round" stroke-linejoin="round" />
-							</svg>
-							导出 CSV
-						</button>
-					</div>
-					<div class="py-2">
-						<div
-							v-for="(page, i) in urlList"
-							:key="i"
-							class="px-5 py-2.5 transition-colors hover:bg-slate-50 dark:hover:bg-slate-700/50"
-						>
-							<div class="mb-1.5 flex items-baseline justify-between gap-2">
-								<span class="max-w-[65%] truncate text-[13px] font-medium text-slate-900 dark:text-slate-100"
-									:title="page.name">
-									{{ shortenUrl(page.name) }}
-								</span>
-								<span class="shrink-0 text-xs text-slate-500 dark:text-slate-400">
-									{{ page.value.toLocaleString() }} 次访问
-								</span>
-							</div>
-							<div class="h-1.5 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
-								<div class="progress-fill"
-									:style="{ width: getPagePct(page.value) + '%', transitionDelay: i * 0.04 + 's' }" />
-							</div>
-						</div>
-					</div>
-				</div>
-
-			</div>
-		</template>
-	</div>
-</template>
-
 <script setup lang="ts" name="clarity">
-import { systemClarity } from '/@/api/admin/system';
-import VChart from 'vue-echarts';
-import { use } from 'echarts/core';
+import { Calendar, Loading, Refresh } from '@element-plus/icons-vue';
 import { PieChart } from 'echarts/charts';
-import { TooltipComponent, GraphicComponent } from 'echarts/components';
+import { GraphicComponent, TooltipComponent } from 'echarts/components';
+import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
+import { storeToRefs } from 'pinia';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { systemClarity } from '/@/api/admin/system';
+import { useThemeConfig } from '/@/stores/themeConfig';
+import ClarityDistributionPanel from './components/clarity/ClarityDistributionPanel.vue';
+import ClarityKpiStrip from './components/clarity/ClarityKpiStrip.vue';
+import ClarityRankingPanel from './components/clarity/ClarityRankingPanel.vue';
+import type { DistributionItem, MetricCard, RankingItem } from './components/clarity/types';
 
 use([PieChart, TooltipComponent, GraphicComponent, CanvasRenderer]);
 
+interface AnalyticsRankingItem {
+	name: string;
+	value: number;
+}
+
+interface AnalyticsData {
+	provider?: string;
+	loading?: boolean;
+	message?: string;
+	deviceData?: string;
+	topUrls?: string;
+	referrerUrlData?: string;
+	pageTitleData?: string;
+	browserData?: string;
+	pageviews?: number;
+	visits?: number;
+	visitors?: number;
+	pagesPerVisit?: number;
+	bounceRate?: number;
+	avgVisitDuration?: number;
+	totalSessions?: number;
+	distinctUsers?: number;
+	pagesPerSession?: number;
+	scrollDepth?: number;
+	deadClickRate?: number;
+	rageClickRate?: number;
+}
+
 const { t } = useI18n();
+const { themeConfig } = storeToRefs(useThemeConfig());
 
 const pageLoading = ref(true);
 const clarityLoading = ref(false);
 const loadingMessage = ref('');
-const clarityData = ref<any>(null);
-const deviceList = ref<{ name: string; value: number }[]>([]);
-const urlList = ref<{ name: string; value: number }[]>([]);
-const referrerList = ref<{ name: string; value: number }[]>([]);
-const pageTitleList = ref<{ name: string; value: number }[]>([]);
-const browserList = ref<{ name: string; value: number }[]>([]);
+const clarityData = ref<AnalyticsData | null>(null);
+const analyticsProvider = ref<'clarity' | 'umami'>('clarity');
+const deviceList = ref<AnalyticsRankingItem[]>([]);
+const urlList = ref<AnalyticsRankingItem[]>([]);
+const referrerList = ref<AnalyticsRankingItem[]>([]);
+const pageTitleList = ref<AnalyticsRankingItem[]>([]);
+const browserList = ref<AnalyticsRankingItem[]>([]);
 const numOfDays = ref(1);
 
-const deviceColors = ['#2E5CF6', '#5B7CFA', '#8EA7FF', '#D8E1FF'];
+const isDark = computed(() => themeConfig.value.isDark);
+const deviceColors = ['#155EEF', '#4D7CFE', '#84A5FF', '#D5E2FF'];
+const browserColors = ['#039BE5', '#36AEEF', '#75C7F5', '#D1EEFC'];
 
 const dayOptions = [
 	{ value: 1, label: '过去 1 天' },
@@ -282,22 +69,42 @@ const dayOptions = [
 	{ value: 3, label: '过去 3 天' },
 ];
 
+const providerLabel = computed(() => (analyticsProvider.value === 'umami' ? 'Umami' : 'Clarity'));
+const listValueUnit = computed(() => (analyticsProvider.value === 'umami' ? '次访问' : '次会话'));
+
+const parseRanking = (value?: string): AnalyticsRankingItem[] => {
+	if (!value) return [];
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter(
+			(item): item is AnalyticsRankingItem =>
+				typeof item === 'object' && item !== null && typeof item.name === 'string' && typeof item.value === 'number'
+		);
+	} catch {
+		return [];
+	}
+};
+
 const loadData = async () => {
 	pageLoading.value = true;
 	clarityLoading.value = false;
 	try {
-		const { data } = await systemClarity(numOfDays.value);
+		const response = await systemClarity(numOfDays.value);
+		const data = response.data as AnalyticsData;
+		analyticsProvider.value = data?.provider === 'umami' ? 'umami' : 'clarity';
 		if (data?.loading) {
 			clarityLoading.value = true;
 			loadingMessage.value = data.message ?? '数据获取中，请稍后手动刷新';
-		} else {
-			clarityData.value = data;
-			deviceList.value = data?.deviceData ? JSON.parse(data.deviceData) : [];
-			urlList.value = data?.topUrls ? JSON.parse(data.topUrls) : [];
-			referrerList.value = data?.referrerUrlData ? JSON.parse(data.referrerUrlData) : [];
-			pageTitleList.value = data?.pageTitleData ? JSON.parse(data.pageTitleData) : [];
-			browserList.value = data?.browserData ? JSON.parse(data.browserData) : [];
+			return;
 		}
+
+		clarityData.value = data;
+		deviceList.value = parseRanking(data?.deviceData);
+		urlList.value = parseRanking(data?.topUrls);
+		referrerList.value = parseRanking(data?.referrerUrlData);
+		pageTitleList.value = parseRanking(data?.pageTitleData);
+		browserList.value = parseRanking(data?.browserData);
 	} catch {
 		// 静默处理
 	} finally {
@@ -305,239 +112,360 @@ const loadData = async () => {
 	}
 };
 
-const selectDays = (v: number) => {
-	numOfDays.value = v;
+const selectDays = (value: number) => {
+	numOfDays.value = value;
 	loadData();
 };
 
 const dateRangeLabel = computed(() => {
 	const today = new Date();
-	const fmt = (d: Date) =>
-		`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-	if (numOfDays.value === 1) return fmt(today);
+	const formatDate = (date: Date) =>
+		`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+	if (numOfDays.value === 1) return formatDate(today);
 	const start = new Date(today);
 	start.setDate(today.getDate() - (numOfDays.value - 1));
-	return `${fmt(start)}  ～  ${fmt(today)}`;
+	return `${formatDate(start)}  ～  ${formatDate(today)}`;
 });
 
-const formatMetricNumber = (val: number | string | null | undefined) => {
-	if (val == null) return '-';
-	const num = Number(val);
-	return Number.isFinite(num) ? new Intl.NumberFormat('zh-CN', { maximumSignificantDigits: 2 }).format(num) : '-';
+const formatMetricNumber = (value: number | string | null | undefined) => {
+	if (value == null) return '-';
+	const number = Number(value);
+	return Number.isFinite(number) ? new Intl.NumberFormat('zh-CN', { maximumSignificantDigits: 2 }).format(number) : '-';
 };
 
-const formatPercent = (val: number | string | null | undefined) => {
-	const text = formatMetricNumber(val);
+const formatPercent = (value: number | string | null | undefined) => {
+	const text = formatMetricNumber(value);
 	return text === '-' ? text : `${text}%`;
 };
 
-function makeBars(seed: number): number[] {
-	const base = [38, 52, 42, 65, 48, 80];
-	return base.map((h, i) => {
-		const jitter = ((seed * (i + 3)) % 23) - 11;
-		return Math.min(95, Math.max(15, h + jitter));
-	});
-}
+const formatDuration = (value: number | string | null | undefined) => {
+	if (value == null) return '-';
+	const seconds = Math.round(Number(value));
+	if (!Number.isFinite(seconds)) return '-';
+	if (seconds < 60) return `${seconds}s`;
+	if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+	return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+};
 
-const statisticsCards = computed(() => {
-	const d = clarityData.value;
+const makeBars = (seed: number): number[] => {
+	const base = [38, 52, 42, 65, 48, 80];
+	return base.map((height, index) => {
+		const jitter = ((seed * (index + 3)) % 23) - 11;
+		return Math.min(95, Math.max(15, height + jitter));
+	});
+};
+
+const statisticsCards = computed<MetricCard[]>(() => {
+	const data = clarityData.value;
+	if (analyticsProvider.value === 'umami') {
+		return [
+			{ label: '浏览量', value: data?.pageviews?.toLocaleString() ?? '-', bars: makeBars(data?.pageviews ?? 42), icon: 'sessions' },
+			{ label: '访问次数', value: data?.visits?.toLocaleString() ?? '-', bars: makeBars(data?.visits ?? 31), icon: 'visitors' },
+			{ label: '独立访客 UV', value: data?.visitors?.toLocaleString() ?? '-', bars: makeBars(data?.visitors ?? 27), icon: 'visitors' },
+			{
+				label: '每次访问浏览页数',
+				value: formatMetricNumber(data?.pagesPerVisit),
+				bars: makeBars(Number(data?.pagesPerVisit ?? 4.8) * 10),
+				icon: 'pages',
+			},
+			{ label: '跳出率', value: formatPercent(data?.bounceRate), bars: makeBars(Number(data?.bounceRate ?? 38) * 2), icon: 'deadClick' },
+			{
+				label: '平均访问时长',
+				value: formatDuration(data?.avgVisitDuration),
+				bars: makeBars(Number(data?.avgVisitDuration ?? 72)),
+				icon: 'scroll',
+			},
+		];
+	}
+
 	return [
-		{ label: t('clarity.totalSessions', '总会话数'), value: d?.totalSessions?.toLocaleString() ?? '-', bars: makeBars(d?.totalSessions ?? 42) },
-		{ label: t('clarity.distinctUsers', '独立访客 UV'), value: d?.distinctUsers?.toLocaleString() ?? '-', bars: makeBars(d?.distinctUsers ?? 31) },
-		{ label: t('clarity.pagesPerSession', '每会话页面数'), value: formatMetricNumber(d?.pagesPerSession), bars: makeBars((d?.pagesPerSession ?? 4.8) * 10) },
-		{ label: t('clarity.scrollDepth', '平均滚动深度'), value: formatPercent(d?.scrollDepth), bars: makeBars((d?.scrollDepth ?? 64) * 2) },
-		{ label: t('clarity.deadClickRate', '死点击率'), value: formatPercent(d?.deadClickRate), bars: makeBars((d?.deadClickRate ?? 28) * 3) },
-		{ label: t('clarity.rageClickRate', '激怒点击率'), value: formatPercent(d?.rageClickRate), bars: makeBars((d?.rageClickRate ?? 0.4) * 100) },
+		{
+			label: t('clarity.totalSessions', '总会话数'),
+			value: data?.totalSessions?.toLocaleString() ?? '-',
+			bars: makeBars(data?.totalSessions ?? 42),
+			icon: 'sessions',
+		},
+		{
+			label: t('clarity.distinctUsers', '独立访客 UV'),
+			value: data?.distinctUsers?.toLocaleString() ?? '-',
+			bars: makeBars(data?.distinctUsers ?? 31),
+			icon: 'visitors',
+		},
+		{
+			label: t('clarity.pagesPerSession', '每会话页面数'),
+			value: formatMetricNumber(data?.pagesPerSession),
+			bars: makeBars((data?.pagesPerSession ?? 4.8) * 10),
+			icon: 'pages',
+		},
+		{
+			label: t('clarity.scrollDepth', '平均滚动深度'),
+			value: formatPercent(data?.scrollDepth),
+			bars: makeBars((data?.scrollDepth ?? 64) * 2),
+			icon: 'scroll',
+		},
+		{
+			label: t('clarity.deadClickRate', '死点击率'),
+			value: formatPercent(data?.deadClickRate),
+			bars: makeBars((data?.deadClickRate ?? 28) * 3),
+			icon: 'deadClick',
+		},
+		{
+			label: t('clarity.rageClickRate', '激怒点击率'),
+			value: formatPercent(data?.rageClickRate),
+			bars: makeBars((data?.rageClickRate ?? 0.4) * 100),
+			icon: 'rageClick',
+		},
 	];
 });
 
-const totalDeviceVisits = computed(() => deviceList.value.reduce((s, i) => s + i.value, 0));
+const totalDeviceVisits = computed(() => deviceList.value.reduce((sum, item) => sum + item.value, 0));
+const totalBrowserVisits = computed(() => browserList.value.reduce((sum, item) => sum + item.value, 0));
 
-const getDevicePct = (val: number) => {
-	const total = totalDeviceVisits.value;
-	return total ? ((val / total) * 100).toFixed(1) : '0';
-};
+const formatPercentage = (value: number, total: number) => (total ? ((value / total) * 100).toFixed(1) : '0');
+const formatTotal = (value: number) => (value >= 1000 ? `${(value / 1000).toFixed(1)}k` : value.toString());
 
-const fmtTotal = (n: number) => (n >= 1000 ? (n / 1000).toFixed(1) + 'k' : n.toString());
+const deviceDistributionItems = computed<DistributionItem[]>(() =>
+	deviceList.value.map((item) => ({ ...item, percentage: formatPercentage(item.value, totalDeviceVisits.value) }))
+);
 
-const deviceChartOption = computed(() => ({
+const browserDistributionItems = computed<DistributionItem[]>(() =>
+	browserList.value.map((item) => ({ ...item, percentage: formatPercentage(item.value, totalBrowserVisits.value) }))
+);
+
+const createPieOption = (items: AnalyticsRankingItem[], colors: string[], total: number) => ({
 	tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
-	color: deviceColors,
-	graphic: [{
-		type: 'group',
-		left: 'center',
-		top: 'center',
-		children: [
-			{
-				type: 'text',
-				z: 100,
-				left: 'center',
-				top: '-14px',
-				style: { text: fmtTotal(totalDeviceVisits.value), font: 'bold 26px system-ui, sans-serif', fill: '#0f172a', textAlign: 'center' },
-			},
-			{
-				type: 'text',
-				z: 100,
-				left: 'center',
-				top: '16px',
-				style: { text: '总访问', font: '11px system-ui, sans-serif', fill: '#94a3b8', textAlign: 'center' },
-			},
-		],
-	}],
-	series: [{
-		type: 'pie',
-		radius: ['52%', '78%'],
-		center: ['50%', '50%'],
-		data: deviceList.value.map((d, i) => ({
-			name: d.name,
-			value: d.value,
-			itemStyle: { color: deviceColors[i % deviceColors.length] },
-		})),
-		label: { show: false },
-		emphasis: { scale: false, itemStyle: { opacity: 0.85 } },
-		itemStyle: { borderRadius: 4, borderColor: '#fff', borderWidth: 2 },
-	}],
-}));
+	color: colors,
+	graphic: [
+		{
+			type: 'group',
+			left: 'center',
+			top: 'center',
+			children: [
+				{
+					type: 'text',
+					z: 100,
+					left: 'center',
+					top: '-14px',
+					style: {
+						text: formatTotal(total),
+						font: '600 26px system-ui, sans-serif',
+						fill: isDark.value ? '#e2e8f0' : '#0f172a',
+						textAlign: 'center',
+					},
+				},
+				{
+					type: 'text',
+					z: 100,
+					left: 'center',
+					top: '17px',
+					style: { text: '总访问', font: '12px system-ui, sans-serif', fill: '#64748b', textAlign: 'center' },
+				},
+			],
+		},
+	],
+	series: [
+		{
+			type: 'pie',
+			radius: ['54%', '78%'],
+			center: ['50%', '50%'],
+			data: items.map((item, index) => ({
+				name: item.name,
+				value: item.value,
+				itemStyle: { color: colors[index % colors.length] },
+			})),
+			label: { show: false },
+			emphasis: { scale: false, itemStyle: { opacity: 0.85 } },
+			itemStyle: { borderRadius: 4, borderColor: isDark.value ? '#1e293b' : '#fff', borderWidth: 2 },
+		},
+	],
+});
 
-const maxPageViews = computed(() => Math.max(...urlList.value.map((u) => u.value), 1));
-
-const getPagePct = (val: number) => ((val / maxPageViews.value) * 100).toFixed(1);
-
-const browserColors = ['#1D9BF0', '#48AEF7', '#84C9FF', '#D6EFFF'];
-
-const totalBrowserVisits = computed(() => browserList.value.reduce((s, i) => s + i.value, 0));
-
-const getBrowserPct = (val: number) => {
-	const total = totalBrowserVisits.value;
-	return total ? ((val / total) * 100).toFixed(1) : '0';
-};
-
-const browserChartOption = computed(() => ({
-	tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
-	color: browserColors,
-	graphic: [{
-		type: 'group',
-		left: 'center',
-		top: 'center',
-		children: [
-			{
-				type: 'text',
-				z: 100,
-				left: 'center',
-				top: '-14px',
-				style: { text: fmtTotal(totalBrowserVisits.value), font: 'bold 26px system-ui, sans-serif', fill: '#0f172a', textAlign: 'center' },
-			},
-			{
-				type: 'text',
-				z: 100,
-				left: 'center',
-				top: '16px',
-				style: { text: '总访问', font: '11px system-ui, sans-serif', fill: '#94a3b8', textAlign: 'center' },
-			},
-		],
-	}],
-	series: [{
-		type: 'pie',
-		radius: ['52%', '78%'],
-		center: ['50%', '50%'],
-		data: browserList.value.map((d, i) => ({
-			name: d.name,
-			value: d.value,
-			itemStyle: { color: browserColors[i % browserColors.length] },
-		})),
-		label: { show: false },
-		emphasis: { scale: false, itemStyle: { opacity: 0.85 } },
-		itemStyle: { borderRadius: 4, borderColor: '#fff', borderWidth: 2 },
-	}],
-}));
-
-const maxReferrerViews = computed(() => Math.max(...referrerList.value.map((u) => u.value), 1));
-const getReferrerPct = (val: number) => ((val / maxReferrerViews.value) * 100).toFixed(1);
-
-const maxPageTitleViews = computed(() => Math.max(...pageTitleList.value.map((u) => u.value), 1));
-const getPageTitlePct = (val: number) => ((val / maxPageTitleViews.value) * 100).toFixed(1);
+const deviceChartOption = computed(() => createPieOption(deviceList.value, deviceColors, totalDeviceVisits.value));
+const browserChartOption = computed(() => createPieOption(browserList.value, browserColors, totalBrowserVisits.value));
 
 const shortenUrl = (url: string) => {
 	try {
-		const u = new URL(url);
-		return u.pathname || url;
+		const parsed = new URL(url);
+		return parsed.pathname || url;
 	} catch {
 		return url.replace(/^https?:\/\/[^/]+/, '') || url;
 	}
 };
 
+const buildRankingItems = (items: AnalyticsRankingItem[], displayName: (item: AnalyticsRankingItem) => string): RankingItem[] => {
+	const max = Math.max(...items.map((item) => item.value), 1);
+	return items.map((item) => ({
+		...item,
+		displayName: displayName(item),
+		progress: ((item.value / max) * 100).toFixed(1),
+	}));
+};
+
+const referrerRankingItems = computed(() => buildRankingItems(referrerList.value, (item) => shortenUrl(item.name)));
+const pageTitleRankingItems = computed(() => buildRankingItems(pageTitleList.value, (item) => item.name));
+const popularRankingItems = computed(() => buildRankingItems(urlList.value, (item) => shortenUrl(item.name)));
+
 const exportCsv = () => {
-	const rows = [['URL', '访问次数'], ...urlList.value.map((u) => [u.name, u.value])];
-	const csv = rows.map((r) => r.join(',')).join('\n');
+	const rows = [['URL', '访问次数'], ...urlList.value.map((item) => [item.name, item.value])];
+	const csv = rows.map((row) => row.join(',')).join('\n');
 	const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
 	const url = URL.createObjectURL(blob);
-	const a = document.createElement('a');
-	a.href = url;
-	a.download = `clarity-top-pages-${dateRangeLabel.value}.csv`;
-	a.click();
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = `${analyticsProvider.value}-top-pages-${dateRangeLabel.value}.csv`;
+	anchor.click();
 	URL.revokeObjectURL(url);
 };
 
-onMounted(() => { loadData(); });
+onMounted(loadData);
 </script>
 
+<template>
+	<div class="min-h-full bg-slate-50 px-4 py-5 dark:bg-slate-950 sm:px-5 xl:px-6">
+		<div v-if="pageLoading" class="animate-pulse" aria-label="站点统计加载中">
+			<div class="mb-4 flex items-center justify-between gap-4">
+				<div class="h-9 w-72 rounded-lg bg-slate-200 dark:bg-slate-700" />
+				<div class="h-9 w-48 rounded-lg bg-slate-200 dark:bg-slate-700" />
+			</div>
+			<div class="mb-4 grid overflow-hidden rounded-xl bg-white sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6 dark:bg-slate-800">
+				<div v-for="index in 6" :key="index" class="h-[144px] border-b border-slate-100 p-5 xl:border-r xl:border-b-0 dark:border-slate-700">
+					<div class="h-3 w-3/5 rounded bg-slate-200 dark:bg-slate-700" />
+					<div class="mt-4 h-7 w-2/5 rounded bg-slate-200 dark:bg-slate-700" />
+					<div class="mt-5 h-7 rounded bg-slate-100 dark:bg-slate-700" />
+				</div>
+			</div>
+			<div class="grid gap-4 xl:grid-cols-2">
+				<div v-for="index in 4" :key="index" class="h-[300px] rounded-xl bg-white dark:bg-slate-800" />
+			</div>
+		</div>
+
+		<div v-else-if="clarityLoading" class="flex min-h-[420px] flex-col items-center justify-center gap-3">
+			<el-icon class="animate-spin text-4xl text-primary"><Loading /></el-icon>
+			<p class="m-0 text-lg font-semibold text-slate-900 dark:text-slate-100">正在从 {{ providerLabel }} 拉取数据</p>
+			<p class="m-0 text-sm text-slate-500 dark:text-slate-400">{{ loadingMessage }}</p>
+			<button type="button" class="reload-button" @click="loadData">
+				<el-icon><Refresh /></el-icon>
+				手动刷新
+			</button>
+		</div>
+
+		<template v-else>
+			<header class="toolbar-surface mb-4">
+				<div class="inline-flex rounded-lg bg-slate-100 p-1 dark:bg-slate-700">
+					<button
+						v-for="option in dayOptions"
+						:key="option.value"
+						type="button"
+						class="day-button"
+						:class="{ 'is-active': numOfDays === option.value }"
+						:aria-pressed="numOfDays === option.value"
+						@click="selectDays(option.value)"
+					>
+						{{ option.label }}
+					</button>
+				</div>
+
+				<div
+					class="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3.5 py-2 text-[13px] font-medium text-slate-600 dark:border-slate-700 dark:text-slate-300"
+				>
+					<el-icon class="text-primary"><Calendar /></el-icon>
+					<span>{{ providerLabel }} · {{ dateRangeLabel }}</span>
+				</div>
+			</header>
+
+			<ClarityKpiStrip class="mb-4" :items="statisticsCards" />
+
+			<div class="grid items-stretch gap-4 xl:grid-cols-2">
+				<ClarityDistributionPanel
+					:title="t('clarity.deviceDistribution', '设备分布')"
+					kind="device"
+					:items="deviceDistributionItems"
+					:colors="deviceColors"
+					:chart-option="deviceChartOption"
+				/>
+				<ClarityDistributionPanel
+					:title="t('clarity.browserDistribution', '浏览器分布')"
+					kind="browser"
+					:items="browserDistributionItems"
+					:colors="browserColors"
+					:chart-option="browserChartOption"
+				/>
+
+				<ClarityRankingPanel :title="t('clarity.referrerUrl', '来源页面 Top5')" kind="referrer" :items="referrerRankingItems" :unit="listValueUnit" />
+				<ClarityRankingPanel :title="t('clarity.pageTitle', '页面标题 Top5')" kind="title" :items="pageTitleRankingItems" :unit="listValueUnit" />
+
+				<ClarityRankingPanel
+					class="xl:col-span-2"
+					:title="t('clarity.popularPages', '热门页面 Top5')"
+					kind="popular"
+					:items="popularRankingItems"
+					unit="次访问"
+					action-label="导出 CSV"
+					@action="exportCsv"
+				/>
+			</div>
+		</template>
+	</div>
+</template>
+
 <style scoped>
-/* 图表区域布局 */
-.charts-grid {
-	grid-template-columns: repeat(2, 1fr);
-}
-
-.charts-grid-full {
-	grid-column: span 2;
-}
-
-@media (max-width: 1100px) {
-	.charts-grid {
-		grid-template-columns: 1fr;
-	}
-	.charts-grid-full {
-		grid-column: span 1;
-	}
-}
-
-/* sparkline — 动态高度必须 scoped */
-.sparkline {
+.toolbar-surface {
 	display: flex;
-	align-items: flex-end;
-	gap: 3px;
-	height: 32px;
-	margin-top: auto;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
 }
 
-.spark-bar {
-	flex: 1;
-	border-radius: 3px 3px 0 0;
-	background: var(--el-color-primary-light-8);
-	transition: height 0.3s ease;
+.day-button {
+	cursor: pointer;
+	white-space: nowrap;
+	border: 0;
+	border-radius: 7px;
+	background: transparent;
+	padding: 8px 15px;
+	color: var(--el-text-color-secondary);
+	font-size: 13px;
+	font-weight: 500;
+	transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.spark-bar.is-active {
+.day-button:hover {
+	color: var(--el-color-primary);
+}
+
+.day-button.is-active {
 	background: var(--el-color-primary);
+	box-shadow: 0 1px 2px rgb(21 94 239 / 0.2);
+	color: white;
 }
 
-[data-theme='dark'] .spark-bar {
-	background: var(--el-color-primary-light-9);
+.reload-button {
+	display: inline-flex;
+	cursor: pointer;
+	align-items: center;
+	gap: 6px;
+	border: 0;
+	border-radius: 8px;
+	background: var(--el-color-primary);
+	padding: 8px 16px;
+	color: white;
+	font-size: 13px;
+	font-weight: 500;
 }
 
-[data-theme='dark'] .spark-bar.is-active {
-	background: var(--el-color-primary-light-3);
-}
+@media (max-width: 640px) {
+	.toolbar-surface {
+		align-items: stretch;
+	}
 
-/* 进度条填充 — 渐变 + cubic-bezier 入场动画 */
-.progress-fill {
-	height: 100%;
-	border-radius: 99px;
-	background: linear-gradient(90deg, var(--el-color-primary), var(--el-color-primary-light-3));
-	width: 0;
-	transition: width 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-}
+	.toolbar-surface > * {
+		width: 100%;
+		justify-content: center;
+	}
 
-.progress-fill-sky {
-	background: linear-gradient(90deg, #1D9BF0, var(--el-color-primary-light-5));
+	.day-button {
+		flex: 1;
+	}
 }
 </style>

--- a/src/views/tools/data/components/clarity/ClarityDistributionPanel.vue
+++ b/src/views/tools/data/components/clarity/ClarityDistributionPanel.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ChromeFilled, Monitor } from '@element-plus/icons-vue';
+import type { Component } from 'vue';
+import VChart from 'vue-echarts';
+import type { DistributionItem, DistributionKind } from './types';
+
+defineProps<{
+	title: string;
+	kind: DistributionKind;
+	items: DistributionItem[];
+	colors: string[];
+	chartOption: object;
+}>();
+
+const iconMap: Record<DistributionKind, Component> = {
+	device: Monitor,
+	browser: ChromeFilled,
+};
+</script>
+
+<template>
+	<section class="panel-surface">
+		<header class="panel-header">
+			<el-icon class="text-base text-slate-500 dark:text-slate-400">
+				<component :is="iconMap[kind]" />
+			</el-icon>
+			<h2 class="m-0 text-[15px] font-semibold text-slate-900 dark:text-slate-100">{{ title }}</h2>
+		</header>
+
+		<div class="grid min-h-[236px] items-center gap-4 px-5 py-4 sm:grid-cols-[minmax(180px,1fr)_180px]">
+			<v-chart class="h-[220px] w-full min-w-0" :option="chartOption" autoresize />
+			<div class="space-y-4">
+				<div v-for="(item, index) in items.slice(0, 3)" :key="item.name" class="min-w-0">
+					<div class="flex items-center gap-2 text-[13px]">
+						<span class="h-2.5 w-2.5 shrink-0 rounded-full" :style="{ backgroundColor: colors[index % colors.length] }" />
+						<span class="min-w-0 flex-1 truncate text-slate-600 dark:text-slate-300">{{ item.name }}</span>
+					</div>
+					<div class="mt-1.5 pl-[18px]">
+						<strong class="text-lg font-semibold leading-none text-slate-900 tabular-nums dark:text-slate-100">{{ item.percentage }}%</strong>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+</template>
+
+<style scoped>
+.panel-surface {
+	overflow: hidden;
+	border: 1px solid var(--el-border-color-lighter);
+	border-radius: 12px;
+	background: var(--el-bg-color);
+	box-shadow: 0 1px 2px rgb(15 23 42 / 0.04);
+}
+
+.panel-header {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 15px 20px;
+	border-bottom: 1px solid var(--el-border-color-lighter);
+}
+</style>

--- a/src/views/tools/data/components/clarity/ClarityKpiStrip.vue
+++ b/src/views/tools/data/components/clarity/ClarityKpiStrip.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { Aim, Document, Pointer, TrendCharts, User } from '@element-plus/icons-vue';
+import type { Component } from 'vue';
+import type { MetricCard, MetricIconName } from './types';
+
+defineProps<{
+	items: MetricCard[];
+}>();
+
+const iconMap: Record<MetricIconName, Component> = {
+	sessions: User,
+	visitors: User,
+	pages: Document,
+	scroll: TrendCharts,
+	deadClick: Aim,
+	rageClick: Pointer,
+};
+</script>
+
+<template>
+	<section class="kpi-strip" aria-label="站点核心指标">
+		<article v-for="item in items" :key="item.label" class="kpi-item">
+			<div class="flex min-w-0 items-center gap-2.5">
+				<span class="kpi-icon" aria-hidden="true">
+					<el-icon><component :is="iconMap[item.icon]" /></el-icon>
+				</span>
+				<span class="truncate text-xs font-medium text-slate-500 dark:text-slate-400">{{ item.label }}</span>
+			</div>
+			<p class="mt-3 mb-0 text-[28px] font-semibold leading-none tracking-tight text-slate-900 tabular-nums dark:text-slate-100">
+				{{ item.value }}
+			</p>
+			<div class="sparkline" aria-hidden="true">
+				<span
+					v-for="(height, index) in item.bars"
+					:key="index"
+					class="spark-bar"
+					:class="{ 'is-active': index === item.bars.length - 1 }"
+					:style="{ height: `${height}%` }"
+				/>
+			</div>
+		</article>
+	</section>
+</template>
+
+<style scoped>
+.kpi-strip {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	overflow: hidden;
+	border: 1px solid var(--el-border-color-lighter);
+	border-radius: 12px;
+	background: var(--el-bg-color);
+	box-shadow: 0 1px 2px rgb(15 23 42 / 0.04);
+}
+
+.kpi-item {
+	min-width: 0;
+	padding: 18px 20px 16px;
+	border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.kpi-item:nth-child(odd) {
+	border-right: 1px solid var(--el-border-color-lighter);
+}
+
+.kpi-icon {
+	display: inline-flex;
+	height: 24px;
+	width: 24px;
+	flex: none;
+	align-items: center;
+	justify-content: center;
+	color: var(--el-color-primary);
+	font-size: 18px;
+}
+
+.sparkline {
+	display: flex;
+	height: 30px;
+	align-items: flex-end;
+	gap: 5px;
+	margin-top: 16px;
+}
+
+.spark-bar {
+	min-width: 4px;
+	flex: 1;
+	border-radius: 3px 3px 1px 1px;
+	background: var(--el-color-primary-light-8);
+	transition: height 0.3s ease;
+}
+
+.spark-bar.is-active {
+	background: var(--el-color-primary);
+}
+
+@media (min-width: 768px) {
+	.kpi-strip {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.kpi-item:nth-child(odd) {
+		border-right: 0;
+	}
+
+	.kpi-item:not(:nth-child(3n)) {
+		border-right: 1px solid var(--el-border-color-lighter);
+	}
+}
+
+@media (min-width: 1280px) {
+	.kpi-strip {
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+	}
+
+	.kpi-item {
+		border-bottom: 0;
+	}
+
+	.kpi-item:not(:last-child) {
+		border-right: 1px solid var(--el-border-color-lighter);
+	}
+}
+
+[data-theme='dark'] .spark-bar {
+	background: var(--el-color-primary-light-9);
+}
+
+[data-theme='dark'] .spark-bar.is-active {
+	background: var(--el-color-primary-light-3);
+}
+</style>

--- a/src/views/tools/data/components/clarity/ClarityRankingPanel.vue
+++ b/src/views/tools/data/components/clarity/ClarityRankingPanel.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { Document, Download, Link, TrendCharts } from '@element-plus/icons-vue';
+import type { Component } from 'vue';
+import type { RankingItem, RankingKind } from './types';
+
+withDefaults(
+	defineProps<{
+		title: string;
+		kind: RankingKind;
+		items: RankingItem[];
+		unit: string;
+		actionLabel?: string;
+	}>(),
+	{
+		actionLabel: '',
+	}
+);
+
+const emit = defineEmits<{
+	action: [];
+}>();
+
+const iconMap: Record<RankingKind, Component> = {
+	referrer: Link,
+	title: Document,
+	popular: TrendCharts,
+};
+</script>
+
+<template>
+	<section class="panel-surface">
+		<header class="panel-header">
+			<div class="flex min-w-0 items-center gap-2.5">
+				<el-icon class="text-base text-slate-500 dark:text-slate-400">
+					<component :is="iconMap[kind]" />
+				</el-icon>
+				<h2 class="m-0 truncate text-[15px] font-semibold text-slate-900 dark:text-slate-100">{{ title }}</h2>
+			</div>
+			<button v-if="actionLabel" type="button" class="action-button" @click="emit('action')">
+				<el-icon><Download /></el-icon>
+				{{ actionLabel }}
+			</button>
+		</header>
+
+		<div class="px-5 py-2">
+			<div
+				class="grid grid-cols-[32px_minmax(0,1fr)_auto] items-center gap-3 border-b border-slate-100 py-2 text-xs font-medium text-slate-500 dark:border-slate-700 dark:text-slate-400"
+			>
+				<span>排名</span>
+				<span>{{ kind === 'title' ? '页面标题' : '来源页面' }}</span>
+				<span class="text-right">{{ unit }}</span>
+			</div>
+
+			<div class="divide-y divide-slate-100 dark:divide-slate-700">
+				<div v-for="(item, index) in items" :key="`${item.name}-${index}`" class="ranking-row">
+					<span class="rank-badge">{{ index + 1 }}</span>
+					<div class="min-w-0">
+						<div class="truncate text-[13px] font-medium text-slate-800 dark:text-slate-100" :title="item.name">
+							{{ item.displayName }}
+						</div>
+						<div class="mt-2 h-1 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
+							<span class="progress-fill" :class="{ 'is-cyan': kind === 'title' }" :style="{ width: `${item.progress}%` }" />
+						</div>
+					</div>
+					<span class="text-right text-xs text-slate-500 tabular-nums dark:text-slate-400"> {{ item.value.toLocaleString() }} {{ unit }} </span>
+				</div>
+			</div>
+		</div>
+	</section>
+</template>
+
+<style scoped>
+.panel-surface {
+	overflow: hidden;
+	border: 1px solid var(--el-border-color-lighter);
+	border-radius: 12px;
+	background: var(--el-bg-color);
+	box-shadow: 0 1px 2px rgb(15 23 42 / 0.04);
+}
+
+.panel-header {
+	display: flex;
+	min-height: 54px;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 12px 20px;
+	border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.ranking-row {
+	display: grid;
+	grid-template-columns: 32px minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 0;
+}
+
+.rank-badge {
+	display: inline-flex;
+	height: 22px;
+	width: 22px;
+	align-items: center;
+	justify-content: center;
+	border-radius: 6px;
+	background: var(--el-color-primary);
+	color: white;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.progress-fill {
+	display: block;
+	height: 100%;
+	border-radius: inherit;
+	background: var(--el-color-primary);
+	transition: width 0.5s ease;
+}
+
+.progress-fill.is-cyan {
+	background: #1d9bf0;
+}
+
+.action-button {
+	display: inline-flex;
+	flex: none;
+	cursor: pointer;
+	align-items: center;
+	gap: 6px;
+	border: 0;
+	border-radius: 8px;
+	background: var(--el-color-primary-light-9);
+	padding: 7px 10px;
+	color: var(--el-color-primary);
+	font-size: 12px;
+	font-weight: 500;
+	transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.action-button:hover {
+	background: var(--el-color-primary);
+	color: white;
+}
+</style>

--- a/src/views/tools/data/components/clarity/types.ts
+++ b/src/views/tools/data/components/clarity/types.ts
@@ -1,0 +1,24 @@
+export type MetricIconName = 'sessions' | 'visitors' | 'pages' | 'scroll' | 'deadClick' | 'rageClick';
+
+export interface MetricCard {
+	label: string;
+	value: string;
+	bars: number[];
+	icon: MetricIconName;
+}
+
+export interface DistributionItem {
+	name: string;
+	value: number;
+	percentage: string;
+}
+
+export interface RankingItem {
+	name: string;
+	displayName: string;
+	value: number;
+	progress: string;
+}
+
+export type DistributionKind = 'device' | 'browser';
+export type RankingKind = 'referrer' | 'title' | 'popular';


### PR DESCRIPTION
## 变更说明

- 将 KPI、分布图和排行拆分为展示组件
- 主页面集中负责数据获取、筛选、格式化与导出
- 保留开源版 `systemClarity` API 契约
- 延续现有指标数值、百分比和时长格式化逻辑
- 支持暗色主题与响应式布局

## 验证

- 修改文件定向 ESLint 通过
- `pnpm build` 通过
- `git diff --check`