### PR TITLE
refactor(home): 优化首页看板主题与响应式布局

### DIFF
--- a/src/views/admin/log/line-chart.vue
+++ b/src/views/admin/log/line-chart.vue
@@ -11,6 +11,7 @@ import { GridComponent, LegendComponent, TitleComponent, ToolboxComponent, Toolt
 import { CanvasRenderer } from 'echarts/renderers';
 import { useI18n } from 'vue-i18n';
 import { useAsyncState } from '@vueuse/core';
+import { useThemeConfig } from '/@/stores/themeConfig';
 
 use([TitleComponent, TooltipComponent, LegendComponent, ToolboxComponent, GridComponent, LineChart, CanvasRenderer]);
 
@@ -18,6 +19,7 @@ use([TitleComponent, TooltipComponent, LegendComponent, ToolboxComponent, GridCo
  * 国际化工具
  */
 const { t } = useI18n();
+const { themeConfig } = storeToRefs(useThemeConfig());
 
 /**
  * 日志统计数据项接口
@@ -41,34 +43,76 @@ const xAxisData = computed(() => logSumData.value.map((item) => formatPast(new D
 const successData = computed(() => logSumData.value.map((item) => item['0'] || 0));
 const failureData = computed(() => logSumData.value.map((item) => item['9'] || 0));
 
+const chartPalette = computed(() => {
+	if (themeConfig.value.isDark) {
+		return {
+			primary: '#60a5fa',
+			failure: '#9ca3af',
+			textPrimary: '#f3f4f6',
+			textRegular: '#d1d5db',
+			textSecondary: '#9ca3af',
+			tooltipBackground: '#273340',
+			tooltipBorder: '#38444d',
+			grid: '#38444d',
+			axisPointer: '#536471',
+			pointBorder: '#1e2732',
+			shadow: 'rgba(0, 0, 0, 0.35)',
+			primaryAreaStart: 'rgba(96, 165, 250, 0.26)',
+			primaryAreaEnd: 'rgba(96, 165, 250, 0.03)',
+			failureAreaStart: 'rgba(156, 163, 175, 0.18)',
+			failureAreaEnd: 'rgba(156, 163, 175, 0.02)',
+		};
+	}
+
+	return {
+		primary: themeConfig.value.primary || '#2e5cf6',
+		failure: '#6b7280',
+		textPrimary: '#303133',
+		textRegular: '#606266',
+		textSecondary: '#6b7280',
+		tooltipBackground: '#ffffff',
+		tooltipBorder: '#e5e7eb',
+		grid: '#e5e7eb',
+		axisPointer: '#d1d5db',
+		pointBorder: '#ffffff',
+		shadow: 'rgba(15, 23, 42, 0.12)',
+		primaryAreaStart: 'rgba(46, 92, 246, 0.22)',
+		primaryAreaEnd: 'rgba(46, 92, 246, 0.02)',
+		failureAreaStart: 'rgba(107, 114, 128, 0.18)',
+		failureAreaEnd: 'rgba(107, 114, 128, 0.02)',
+	};
+});
+
 /**
  * 图表配置选项（使用 computed 实现国际化动态更新）
  */
 const option = computed(() => ({
+	backgroundColor: 'transparent',
 	title: {
 		textStyle: {
 			fontSize: 16,
 			fontWeight: 500,
-			color: '#303133',
+			color: chartPalette.value.textPrimary,
 		},
 		padding: [20, 0, 0, 20],
 	},
 	tooltip: {
 		trigger: 'axis',
-		backgroundColor: '#ffffff',
+		backgroundColor: chartPalette.value.tooltipBackground,
+		borderColor: chartPalette.value.tooltipBorder,
 		borderRadius: 8,
 		padding: [12, 16],
-		borderWidth: 0,
-		shadowColor: 'rgba(0, 0, 0, 0.1)',
+		borderWidth: 1,
+		shadowColor: chartPalette.value.shadow,
 		shadowBlur: 12,
 		shadowOffsetY: 4,
 		textStyle: {
-			color: '#303133',
+			color: chartPalette.value.textPrimary,
 		},
 		axisPointer: {
 			type: 'line',
 			lineStyle: {
-				color: '#ebeef5',
+				color: chartPalette.value.axisPointer,
 				width: 1,
 				type: 'dashed',
 			},
@@ -80,7 +124,7 @@ const option = computed(() => ({
 		itemWidth: 8,
 		itemHeight: 8,
 		textStyle: {
-			color: '#606266',
+			color: chartPalette.value.textRegular,
 			fontSize: 12,
 		},
 		right: '20px',
@@ -104,14 +148,14 @@ const option = computed(() => ({
 			show: false,
 		},
 		axisLabel: {
-			color: '#909399',
+			color: chartPalette.value.textSecondary,
 			fontSize: 12,
 			margin: 16,
 		},
 		splitLine: {
 			show: true,
 			lineStyle: {
-				color: '#ebeef5',
+				color: chartPalette.value.grid,
 				type: 'dashed',
 			},
 		},
@@ -120,12 +164,12 @@ const option = computed(() => ({
 		type: 'value',
 		splitLine: {
 			lineStyle: {
-				color: '#ebeef5',
+				color: chartPalette.value.grid,
 				type: 'dashed',
 			},
 		},
 		axisLabel: {
-			color: '#909399',
+			color: chartPalette.value.textSecondary,
 			fontSize: 12,
 			margin: 16,
 		},
@@ -146,8 +190,8 @@ const option = computed(() => ({
 			symbol: 'circle',
 			symbolSize: 8,
 			itemStyle: {
-				color: '#79bbff',
-				borderColor: '#fff',
+				color: chartPalette.value.primary,
+				borderColor: chartPalette.value.pointBorder,
 				borderWidth: 2,
 			},
 			lineStyle: {
@@ -163,11 +207,11 @@ const option = computed(() => ({
 					colorStops: [
 						{
 							offset: 0,
-							color: 'rgba(121, 187, 255, 0.2)',
+							color: chartPalette.value.primaryAreaStart,
 						},
 						{
 							offset: 1,
-							color: 'rgba(121, 187, 255, 0.02)',
+							color: chartPalette.value.primaryAreaEnd,
 						},
 					],
 				},
@@ -182,8 +226,8 @@ const option = computed(() => ({
 			symbol: 'circle',
 			symbolSize: 8,
 			itemStyle: {
-				color: '#909399',
-				borderColor: '#fff',
+				color: chartPalette.value.failure,
+				borderColor: chartPalette.value.pointBorder,
 				borderWidth: 2,
 			},
 			lineStyle: {
@@ -199,11 +243,11 @@ const option = computed(() => ({
 					colorStops: [
 						{
 							offset: 0,
-							color: 'rgba(144, 147, 153, 0.2)',
+							color: chartPalette.value.failureAreaStart,
 						},
 						{
 							offset: 1,
-							color: 'rgba(144, 147, 153, 0.02)',
+							color: chartPalette.value.failureAreaEnd,
 						},
 					],
 				},
@@ -211,7 +255,6 @@ const option = computed(() => ({
 		},
 	],
 }));
-
 </script>
 
 <style scoped>

--- a/src/views/home/news/content.vue
+++ b/src/views/home/news/content.vue
@@ -6,7 +6,7 @@
           {{ currentNew.title }}
         </h1>
 
-        <div class="flex items-center mb-8 space-x-4 text-sm text-gray-400">
+        <div class="flex items-center mb-8 space-x-4 text-sm text-gray-500 dark:text-gray-400">
           <span>{{ currentNew.createBy }}</span>
           <span>·</span>
           <span>{{ currentNew.createTime }}</span>
@@ -18,7 +18,7 @@
         <div class="text-base leading-relaxed text-gray-700 dark:text-gray-300" v-html="currentNew.content"></div>
 
         <div class="pt-6 mt-12 text-center border-t border-gray-100 dark:border-gray-800">
-          <span class="text-xs text-gray-400 dark:text-gray-600">{{ t('home.thanksForReading') }}</span>
+          <span class="text-xs text-gray-500 dark:text-gray-400">{{ t('home.thanksForReading') }}</span>
         </div>
       </div>
     </div>

--- a/src/views/home/widgets/components/calendar.vue
+++ b/src/views/home/widgets/components/calendar.vue
@@ -7,7 +7,7 @@ export default {
 </script>
 
 <template>
-	<el-card class="h-96 box-card">
+	<el-card class="h-[360px] min-[992px]:h-96 box-card">
 		<Calendar :first-day-of-week="1" view="weekly" :locale="locale" :attributes="reminders" ref="calendar"
 			title-position="center" @did-move="weeknumberClick" @dayclick="dayClick" :masks="masks"
 			v-bind="themeConfig?.isDark ? { 'is-dark': true } : {}" transparent borderless expanded />
@@ -22,7 +22,7 @@ export default {
 									<p class="text-[13px] font-medium text-gray-700 dark:text-gray-300 truncate">
 										{{ cell.data.customData.title }}
 									</p>
-									<p class="text-xs text-gray-400 mt-0.5">
+									<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
 										{{ cell.data.customData.scheduleDate }} {{ cell.data.customData.scheduleTime }}
 									</p>
 								</div>

--- a/src/views/home/widgets/components/current-user.vue
+++ b/src/views/home/widgets/components/current-user.vue
@@ -27,7 +27,7 @@ export default {
 				<h2 class="text-lg font-semibold leading-tight tracking-tight text-gray-900 truncate dark:text-gray-50">
 					{{ userData.name || userData.username }}
 				</h2>
-				<p class="mt-0.5 text-xs text-gray-400 truncate dark:text-gray-500">@{{ userData.username }}</p>
+				<p class="mt-0.5 text-xs text-gray-500 truncate dark:text-gray-400">@{{ userData.username }}</p>
 
 				<!-- 次层：角色标签 -->
 				<div v-if="userRoles.length" class="flex flex-wrap gap-1.5 mt-3">
@@ -40,8 +40,8 @@ export default {
 					</span>
 				</div>
 
-					<!-- 辅层：部门/职位 -->
-					<p v-if="subInfo" class="mt-2.5 text-xs text-gray-400 dark:text-gray-500 truncate">{{ subInfo }}</p>
+				<!-- 辅层：部门/职位 -->
+				<p v-if="subInfo" class="mt-2.5 text-xs text-gray-500 dark:text-gray-400 truncate">{{ subInfo }}</p>
 			</div>
 		</div>
 	</el-card>

--- a/src/views/home/widgets/components/device-distribution.vue
+++ b/src/views/home/widgets/components/device-distribution.vue
@@ -6,7 +6,7 @@ export default {
 };
 </script>
 <template>
-	<el-card v-loading="loading" class="box-card h-96">
+	<el-card v-loading="loading" class="box-card h-[340px] min-[992px]:h-96">
 		<template #header>
 			<div class="flex items-center justify-between">
 				<span class="text-[15px] font-semibold text-gray-800 dark:text-gray-100">设备分布</span>
@@ -28,11 +28,11 @@ export default {
 					<div v-for="(item, i) in deviceList.slice(0, 3)" :key="i" class="w-full px-1 py-1">
 						<div class="flex items-center gap-2 text-[13px]">
 							<span class="h-2.5 w-2.5 shrink-0 rounded-full" :style="{ background: colors[i % colors.length] }" />
-							<span class="truncate text-slate-500 dark:text-slate-400">{{ item.name }}</span>
+							<span class="truncate text-gray-500 dark:text-gray-400">{{ item.name }}</span>
 						</div>
 						<div class="flex items-end justify-between gap-2 mt-1">
-							<span class="text-lg font-semibold text-slate-900 dark:text-slate-100">{{ getPct(item.value) }}%</span>
-							<span class="text-xs text-slate-400 dark:text-slate-500">{{ item.value }}</span>
+							<span class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ getPct(item.value) }}%</span>
+							<span class="text-xs text-gray-500 dark:text-gray-400">{{ item.value }}</span>
 						</div>
 					</div>
 				</div>

--- a/src/views/home/widgets/components/news.vue
+++ b/src/views/home/widgets/components/news.vue
@@ -6,7 +6,7 @@ export default {
 };
 </script>
 <template>
-	<el-card class="h-96">
+	<el-card class="min-h-[280px] min-[992px]:h-96">
 		<template #header>
 			<div class="flex justify-between items-center">
 				<span class="text-[15px] font-semibold text-gray-800 dark:text-gray-100">{{ $t('home.newsletterTip') }}</span>
@@ -27,7 +27,7 @@ export default {
 					<div class="w-1 h-8 rounded-full flex-shrink-0" :class="item.readFlag === '1' ? 'bg-gray-200 dark:bg-gray-600' : 'bg-primary'"></div>
 					<div class="flex-1 min-w-0">
 						<p class="text-[13px] text-gray-700 dark:text-gray-300 truncate">{{ item.title }}</p>
-						<p class="text-xs text-gray-400 mt-0.5">{{ item.createTime }}</p>
+						<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ item.createTime }}</p>
 					</div>
 					<el-tag size="small" :type="item.readFlag === '1' ? 'info' : 'warning'" effect="plain" round class="text-xs flex-shrink-0">
 						{{ item.readFlag === '1' ? $t('msg.readed') : $t('msg.unread') }}

--- a/src/views/home/widgets/components/popular-pages.vue
+++ b/src/views/home/widgets/components/popular-pages.vue
@@ -6,7 +6,7 @@ export default {
 };
 </script>
 <template>
-	<el-card v-loading="loading" class="box-card h-96">
+	<el-card v-loading="loading" class="box-card h-[340px] min-[992px]:h-96">
 		<template #header>
 			<div class="flex items-center justify-between">
 				<span class="text-[15px] font-semibold text-gray-800 dark:text-gray-100">热门页面</span>

--- a/src/views/home/widgets/components/sys-log-line.vue
+++ b/src/views/home/widgets/components/sys-log-line.vue
@@ -6,7 +6,7 @@ export default {
 };
 </script>
 <template>
-	<el-card class="box-card h-96">
+	<el-card class="box-card h-[340px] min-[992px]:h-96">
 		<template #header>
 			<div class="flex items-center justify-between">
 				<span class="text-[15px] font-semibold text-gray-800 dark:text-gray-100">{{ $t('home.requestLineChartTip') }}</span>

--- a/src/views/home/widgets/components/sys-log.vue
+++ b/src/views/home/widgets/components/sys-log.vue
@@ -6,7 +6,7 @@ export default {
 };
 </script>
 <template>
-	<el-card class="h-96 box-card">
+	<el-card class="min-h-[300px] min-[992px]:h-96 box-card">
 		<template #header>
 			<div class="flex items-center justify-between">
 				<span class="text-[15px] font-semibold text-gray-800 dark:text-gray-100">{{ $t('home.systemLogsTip') }}</span>
@@ -22,9 +22,9 @@ export default {
 					<div class="w-2 h-2 rounded-full bg-primary mt-1.5 flex-shrink-0"></div>
 					<div class="flex-1 min-w-0">
 						<p class="text-[13px] text-gray-700 dark:text-gray-300 leading-relaxed">{{ item.title }}</p>
-						<p class="text-xs text-gray-400 mt-0.5">{{ item.remoteAddr }}</p>
+						<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ item.remoteAddr }}</p>
 					</div>
-					<span class="flex-shrink-0 text-xs text-gray-400 whitespace-nowrap">{{ item.createTime }}</span>
+					<span class="flex-shrink-0 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">{{ item.createTime }}</span>
 				</div>
 			</div>
 		</div>

--- a/src/views/home/widgets/index.vue
+++ b/src/views/home/widgets/index.vue
@@ -3,8 +3,8 @@
  -->
 <template>
 	<div>
-		<div :class="['flex flex-row flex-1 h-full', customizing ? 'customizing' : '']" ref="main">
-			<div class="flex-1 overflow-auto overflow-x-hidden p-[3px]">
+		<div :class="['dashboard-widgets flex flex-row flex-1 h-full', customizing ? 'customizing' : '']" ref="main">
+			<div class="flex-1 min-w-0 overflow-auto overflow-x-hidden p-3">
 				<div class="flex items-center justify-between">
 					<div class="flex justify-end custom_btn">
 						<el-button v-if="customizing" type="primary" round @click="save">{{ t('home.widgets.done') }}</el-button>
@@ -16,7 +16,7 @@
 						<div v-if="nowCompsList.length <= 0" class="p-5 text-center no-widgets">
 							<el-empty :description="t('home.widgets.emptyDashboard')" :image-size="120"></el-empty>
 						</div>
-						<el-row :gutter="2">
+						<el-row :gutter="12">
 							<el-col v-for="(item, index) in grid.layout" v-bind:key="index" :md="item" :xs="24">
 								<draggable
 									v-model="grid.copmsList[index]"
@@ -33,7 +33,16 @@
 										<div class="widgets-item">
 											<component :is="allComps[element as keyof typeof allComps]"></component>
 											<div v-if="customizing" class="customize-overlay">
-												<el-button class="close" type="danger" plain icon="Close" size="small" @click="remove(element)"></el-button>
+												<el-button
+													class="close"
+													type="danger"
+													circle
+													size="small"
+													:aria-label="`${t('common.delBtn')} ${getWidgetTitle(element)}`"
+													@click.stop="remove(element)"
+												>
+													<el-icon><Close /></el-icon>
+												</el-button>
 												<label v-if="allComps[element as keyof typeof allComps]">
 													<el-icon v-if="allComps[element as keyof typeof allComps].icon">
 														<component :is="allComps[element as keyof typeof allComps].icon" />
@@ -50,12 +59,12 @@
 				</div>
 			</div>
 			<div v-if="customizing" class="widgets-aside">
-				<el-container>
-					<el-header>
+				<el-container class="h-full">
+					<el-header class="flex items-center justify-between">
 						<div class="flex items-center justify-center text-sm">{{ t('home.widgets.addWidget') }}</div>
-						<div class="text-lg w-[30px] h-[30px] flex items-center justify-center rounded-lg cursor-pointer transition-colors hover:bg-black/5" @click="close()">
+						<el-button class="widgets-aside-close" text circle size="small" :aria-label="t('tagsView.close')" @click="close">
 							<el-icon><Close /></el-icon>
-						</div>
+						</el-button>
 					</el-header>
 					<el-header style="height: auto">
 						<div class="p-3 selectLayout">
@@ -87,18 +96,24 @@
 							<div v-if="myCompsList.length <= 0" class="p-5 text-center widgets-list-nodata">
 								<el-empty :description="t('home.widgets.allAdded')" :image-size="100"></el-empty>
 							</div>
-							<div v-for="item in myCompsList" :key="item.title" class="flex flex-row p-4 items-center hover:bg-black/[0.03] rounded-lg">
-								<div class="w-10 h-10 rounded-[10px] bg-black/[0.04] flex items-center justify-center text-lg mr-4 text-primary">
+							<div
+								v-for="item in myCompsList"
+								:key="item.title"
+								class="flex flex-row p-4 items-center rounded-lg transition-colors hover:bg-fill-lighter"
+							>
+								<div class="w-10 h-10 rounded-[10px] bg-fill-lighter flex items-center justify-center text-lg mr-4 text-primary">
 									<el-icon>
 										<component :is="item.icon" />
 									</el-icon>
 								</div>
 								<div class="flex-1">
 									<h2 class="text-[15px] font-medium cursor-default">{{ item.title }}</h2>
-									<p class="text-xs text-gray-400 cursor-default">{{ item.description }}</p>
+									<p class="text-xs text-gray-500 dark:text-gray-400 cursor-default">{{ item.description }}</p>
 								</div>
 								<div class="item-actions">
-									<el-button type="primary" icon="el-icon-plus" size="small" @click="push(item)"></el-button>
+									<el-button type="primary" circle size="small" :aria-label="`${t('common.addBtn')} ${item.title}`" @click="push(item)">
+										<el-icon><Plus /></el-icon>
+									</el-button>
 								</div>
 							</div>
 						</div>
@@ -220,6 +235,10 @@ const myCompsList = computed(() => {
 
 const nowCompsList = computed(() => grid.value.copmsList.flat());
 
+const getWidgetTitle = (itemKey: string): string => {
+	return (allComps as Record<string, WidgetComponent>)[itemKey]?.title || itemKey;
+};
+
 const custom = (): void => {
 	toggleCustomizing(true);
 };
@@ -304,6 +323,11 @@ onMounted(async () => {
 	z-index: 9;
 }
 
+.dashboard-widgets {
+	min-width: 0;
+	position: relative;
+}
+
 .widgets-aside {
 	width: 360px;
 	background: var(--el-bg-color-overlay);
@@ -325,8 +349,8 @@ onMounted(async () => {
 	width: 100%;
 }
 
-.customizing .widgets-wrapper .el-col {
-	padding-bottom: 10px;
+.widgets-wrapper .el-col {
+	padding-bottom: 0;
 }
 
 .customizing .widgets-wrapper .draggable-box {
@@ -342,7 +366,7 @@ onMounted(async () => {
 	background: var(--el-bg-color-overlay);
 	border: 1px solid var(--el-border-color-lighter);
 	border-radius: 12px;
-	margin-bottom: 2px;
+	margin-bottom: 12px;
 	min-height: 100px;
 	position: relative;
 	transition: box-shadow 0.2s ease, border-color 0.2s ease;
@@ -408,6 +432,7 @@ onMounted(async () => {
 .selectLayout {
 	width: 100%;
 	display: flex;
+	gap: 16px;
 }
 
 .selectLayout-item {
@@ -416,7 +441,6 @@ onMounted(async () => {
 	border: 2px solid var(--el-border-color-lighter);
 	padding: 5px;
 	cursor: pointer;
-	margin-right: 16px;
 	border-radius: 8px;
 	transition: border-color 0.15s ease;
 }
@@ -470,11 +494,20 @@ onMounted(async () => {
 		transform: scale(1) !important;
 	}
 	.customizing .widgets-aside {
-		width: 100%;
-		position: absolute;
-		top: 50%;
+		position: fixed;
+		z-index: 20;
+		top: auto;
 		right: 0;
 		bottom: 0;
+		left: 0;
+		width: 100%;
+		height: min(60vh, 520px);
+		max-height: calc(100vh - 80px);
+		margin: 0;
+		border-top: 1px solid var(--el-border-color);
+		border-left: 0;
+		border-radius: 16px 16px 0 0;
+		box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.18);
 	}
 	.customizing .widgets-wrapper {
 		margin-right: 0;


### PR DESCRIPTION
## 变更说明

- 改善首页卡片间距、暗色主题、移动端高度与自定义侧栏
- 优化请求趋势图、公告、日历、设备、热门页面和日志组件
- 增加按钮可访问性标签
- 明确排除商业版独有的审计日志组件

## 验证

- 修改文件定向 ESLint 通过
- `pnpm build` 通过
- `git diff --check`