### PR TITLE
fix(docker): 按关键字拦截敏感 API 路径

### DIFF
--- a/docker/pig-ui.conf
+++ b/docker/pig-ui.conf
@@ -35,8 +35,9 @@ server {
         proxy_cache off;
         chunked_transfer_encoding off;
 
-        # 屏蔽所有敏感路径，避免忘记配置关闭，双重保护
-        location ~ ^/api/([^/]+/)?(actuator|swagger-ui|v3/api-docs|swagger-resources|webjars|doc\.html|druid) {
+        # 屏蔽敏感路径（双重保护）：URI 中包含以下关键字即 403
+        # 必须写在 ^~/api/ 内部，否则 ^~ 会跳过同级正则
+        location ~* (actuator|swagger-ui|v3/api-docs|swagger-resources|webjars|doc\.html|druid) {
             return 403;
         }
     }

--- a/docker/pig-ui.conf
+++ b/docker/pig-ui.conf
@@ -37,7 +37,7 @@ server {
 
         # 屏蔽敏感路径（双重保护）：URI 中包含以下关键字即 403
         # 必须写在 ^~/api/ 内部，否则 ^~ 会跳过同级正则
-        location ~* (actuator|swagger-ui|v3/api-docs|swagger-resources|doc\.html|druid) {
+        location ~* (actuator|swagger|v3/api-docs|doc\.html|druid) {
             return 403;
         }
     }

--- a/docker/pig-ui.conf
+++ b/docker/pig-ui.conf
@@ -37,7 +37,7 @@ server {
 
         # 屏蔽敏感路径（双重保护）：URI 中包含以下关键字即 403
         # 必须写在 ^~/api/ 内部，否则 ^~ 会跳过同级正则
-        location ~* (actuator|swagger-ui|v3/api-docs|swagger-resources|webjars|doc\.html|druid) {
+        location ~* (actuator|swagger-ui|v3/api-docs|swagger-resources|doc\.html|druid) {
             return 403;
         }
     }


### PR DESCRIPTION
## Summary

- 修复 Docker Nginx 敏感路径屏蔽：URI **包含**以下关键字即返回 403  
  `actuator` | `swagger` | `v3/api-docs` | `doc.html` | `druid`
- 使用 `~*` 大小写不敏感匹配，覆盖 `swagger-ui`、`swagger-resources` 等变体（不再单独列举）
- 不拦截 `webjars`，避免误伤合法静态依赖
- 规则嵌套在 `location ^~/api/` 内，避免 `^~` 跳过同级正则导致屏蔽失效
- 作为应用侧关闭文档/监控端点之外的 Nginx 双重保护

## Why

此前匹配依赖固定前缀形态（如紧跟 `/api/` 或仅一层服务名），实际访问常为 `/api/admin/swagger-ui.html`、`/api/admin/actuator/health` 等，规则容易漏拦。

## Impact

- **运维/部署**：使用 `docker/pig-ui.conf` 的部署需重载或重建前端容器后生效
- **开发联调**：经 Nginx 访问 Swagger / Actuator / Druid / Knife4j 等调试端点会 403；本地直连网关端口不受影响
- **业务 API**：正常业务路径只要不包含上述关键字，行为不变

## Test plan

- [ ] 重载/重建前端 Nginx 容器使配置生效
- [ ] `curl -i http://<host>/api/admin/actuator/health` → 403
- [ ] `curl -i http://<host>/api/admin/swagger-ui.html` → 403
- [ ] `curl -i http://<host>/api/admin/v3/api-docs` → 403
- [ ] `curl -i http://<host>/api/admin/doc.html` → 403
- [ ] 含 `webjars` 的合法依赖路径不被误拦
- [ ] 正常业务接口（如登录、用户信息）仍可访问
