### PR TITLE
refactor(codegen): 移除 vform 无用代码

### DIFF
--- a/src/api/gen/table.ts
+++ b/src/api/gen/table.ts
@@ -78,22 +78,6 @@ export const checkGeneratorPath = (path: string) => {
 	});
 };
 
-export const useGeneratorVFormApi = (dsName: any, tableName: any) => {
-	return request({
-		url: '/gen/generator/vform',
-		method: 'get',
-		params: { dsName: dsName, tableName: tableName },
-	});
-};
-
-export const useGeneratorVFormSfcApi = (id: string) => {
-	return request({
-		url: '/gen/generator/vform/sfc',
-		method: 'get',
-		params: { formId: id },
-	});
-};
-
 export const useGeneratorPreviewApi = (tableId: any) => {
 	return request({
 		url: '/gen/generator/preview',
@@ -106,36 +90,6 @@ export function fetchDictList() {
 	return request({
 		url: '/admin/dict/list',
 		method: 'get',
-	});
-}
-
-export function useFormConfSaveApi(obj?: Object) {
-	return request({
-		url: '/gen/form',
-		method: 'post',
-		data: obj,
-	});
-}
-
-export function fetchFormList(query?: Object) {
-	return request({
-		url: '/gen/form/page',
-		method: 'get',
-		params: query,
-	});
-}
-
-export function fetchFormById(id?: string) {
-	return request({
-		url: '/gen/form/' + id,
-		method: 'get',
-	});
-}
-
-export function delFormObj(id?: string) {
-	return request({
-		url: '/gen/form/' + id,
-		method: 'delete',
 	});
 }
 

--- a/src/views/gen/table/generator.vue
+++ b/src/views/gen/table/generator.vue
@@ -682,7 +682,7 @@ const submitHandle = async () => {
 const genGroupList = () => {
 	groupList().then(({ data }) => {
 		if (data && data.length > 0) {
-			groupDataList.value = data.filter((group: { groupName: String }) => !group.groupName.includes('vform'));
+			groupDataList.value = data;
 		}
 	});
 };


### PR DESCRIPTION
## 变更内容

- 删除未使用的 vform 生成与表单配置 API 封装。
- 移除生成分组列表中针对 `vform` 的遗留过滤逻辑。

## 原因

后端 vform 能力已退出当前代码链路，前端仍保留不可达的 API 方法和特殊分组过滤，属于无调用方的遗留代码。

## 影响

代码生成页将直接展示后端返回的全部分组；其余生成流程不变。

## 验证

- `pnpm exec eslint src/api/gen/table.ts src/views/gen/table/generator.vue`
- `pnpm build`
- 全仓检索确认无剩余 vform API 或页面引用
- `git diff --check`